### PR TITLE
Fix Member Variable Initialization in Constructor --cppcheck

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -4,7 +4,7 @@
   Copyright (C) 2008-2015 Marco Costalba, Joona Kiiski, Tord Romstad
   Copyright (C) 2015-2016 Marco Costalba, Joona Kiiski, Gary Linscott, Tord Romstad
 
-  Stockfish is free software: you can redistribute it and/or modify
+  Stockfish is free software: you can redistribute it and/or modifyrootm
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
@@ -53,7 +53,10 @@ struct Stack {
 
 struct RootMove {
 
-  explicit RootMove(Move m) : pv(1, m) {}
+  explicit RootMove(Move m) : pv(1, m) {
+    Value score = -VALUE_INFINITE;
+    Value previousScore = -VALUE_INFINITE;
+  }
 
   bool operator<(const RootMove& m) const { return m.score < score; } // Descending sort
   bool operator==(const Move& m) const { return pv[0] == m; }


### PR DESCRIPTION
Fix Member Variable Initialization in Constructor --cppcheck.
